### PR TITLE
Fixed error in loading system.js

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,7 +3,7 @@
     <head>
         <meta charset="utf-8">
         <title>Ember.js • TodoMVC</title>
-        <script src="vendor/system@0.6.js"></script>
+        <script src="vendor/system.js"></script>
         <script src="config.js"></script>
         <script>
             System.import('app/app').then(function(m) {


### PR DESCRIPTION
index.html was requiring `vendor/system@0.6.js`, which was not present, and was causing `ReferenceError: System not defined`.

`vendor/system@0.6.js` wasn't present. Looking in the `vendor` folder, `system.js` was present. Switched src strings and included `vendor/system.js`, which corrected the load error. App loaded fine afterward.
